### PR TITLE
migration table with events updated. Startdate and Enddate

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,6 +174,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.15.5-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.15.5-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.15.5-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
@@ -284,6 +286,7 @@ GEM
 PLATFORMS
   aarch64-linux
   arm64-darwin-22
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/db/migrate/20231128170707_change_start_date_time_end_date_time_events.rb
+++ b/db/migrate/20231128170707_change_start_date_time_end_date_time_events.rb
@@ -1,0 +1,9 @@
+class ChangeStartDateTimeEndDateTimeEvents < ActiveRecord::Migration[7.1]
+  def change
+    change_table :events do |t|
+      t.remove :start_date, :end_date, :start_time, :end_time
+      t.datetime :start_date
+      t.datetime :end_date
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_27_164319) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_28_170707) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -47,13 +47,11 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_27_164319) do
     t.string "title"
     t.string "location"
     t.string "description"
-    t.date "start_date"
-    t.date "end_date"
-    t.time "start_time"
-    t.time "end_time"
     t.bigint "team_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "start_date"
+    t.datetime "end_date"
     t.index ["team_id"], name: "index_events_on_team_id"
   end
 


### PR DESCRIPTION
In the migrations file, there was a change to the start_date and end_date. Rails added a "created_at" and "updated at" too.